### PR TITLE
[actions] Add merge action for linting commit messages.

### DIFF
--- a/.github/workflows/commit_message_linter.yaml
+++ b/.github/workflows/commit_message_linter.yaml
@@ -1,0 +1,13 @@
+---
+name: commit-message-linter
+on:
+  merge_group:
+jobs:
+  lint-commit-message:
+    runs-on: ubuntu-latest
+    env:
+      COMMIT_MESSAGE: ${{github.event.head_commit.message}}
+    steps:
+    - uses: actions/checkout@v3
+    - id: run-commit-message-linter
+      run: ./ci/commit_message_linter.sh

--- a/ci/commit_message_linter.sh
+++ b/ci/commit_message_linter.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+if [[ -z "${COMMIT_MESSAGE}" ]]; then
+  echo "No commit message"
+  exit 2
+fi
+
+# Check that there's a summary.
+echo "$COMMIT_MESSAGE" | grep -E "^Summary: .+" > /dev/null || (echo "Commit message must include Summary: <summary>" && exit 100)
+
+# Check that there's a test plan.
+echo "$COMMIT_MESSAGE" | grep -E "^Test Plan: .+" > /dev/null || (echo "Commit message must include Test Plan: <test plan>" && exit 100)
+
+# Check that there's a Type of Change field.
+echo "$COMMIT_MESSAGE" | grep -E "^Type of change: /kind \w+" > /dev/null || (
+  echo "Commit message must include Type of change: /kind <change_kind>" && exit 100
+)
+
+# Check that no lines begin with whitespace.
+lines_start_whitespace="$(echo "$COMMIT_MESSAGE" | grep -nE "^\W" || true)"
+[[ -z "${lines_start_whitespace}" ]] || (echo -e "Line(s) begin with whitespace:\n${lines_start_whitespace}" && exit 100)
+
+# Check that no lines end with whitespace.
+lines_end_whitespace="$(echo "$COMMIT_MESSAGE" | grep -nE "\s$" || true)"
+[[ -z "${lines_end_whitespace}" ]] || (echo -e "Line(s) end with whitespace:\n${lines_end_whitespace}" && exit 100)
+
+# Check that each "Key:" has text after it.
+keys_without_text="$(echo "$COMMIT_MESSAGE" | grep -E "^[a-zA-Z ]+:" | grep -nE "^[a-zA-Z ]+:\s*$" || true)"
+[[ -z "${keys_without_text}" ]] || (echo -e "Each 'Key:' clause must have text after it:\n${keys_without_text}" && exit 100)
+
+# Check that there's a newline before each "Key:" clause (except if the clause is at the start of the message).
+keys_without_newlines="$(echo "$COMMIT_MESSAGE" | grep -E -B 1 "^[a-zA-Z ]+:" | grep -Ev "^[a-zA-Z ]+:" | grep -v "\-\-" | sed '/^$/d' )"
+[[ -z "${keys_without_newlines}" ]] || (
+  echo -e "Each 'Key:' clause must have a newline before it, add newlines after:\n${keys_without_newlines}" && exit 100
+)


### PR DESCRIPTION
Summary: Adds a github action to lint commit messages. This will lead to more consistent commit messages.

Type of change: /kind feature

Test Plan: Tested the script locally. Using pull_request to test the github action.

Signed-off-by: James Bartlett <jamesbartlett@pixielabs.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/pixie-io/pixie/blob/main/CONTRIBUTING.md and https://github.com/pixie-io/pixie/blob/main/DEVELOPMENT.md.

Also, please delete all the comment blocks to make it easier for the maintainers to compose the final error message from this doc.

All the fields need to be filled out inline. For example:
Summary: Here is a description of this change, and
it's allowed to span multiple lines.

Leave an empty line between each block.
-->
Summary: <!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Relevant Issues: <!--
Please list all the relevant issues (#<issue number>): eg. #1, #2. If the PR fixes an issue use `Fixes #<issue number>`
-->

Type of change: <!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

Test Plan: <!--
For stylistic change that don't require tests or enhancements write: N/A.
-->

Changelog Message: <!--

Does this PR include user facing changes?

If no, just delete this entire block.
If yes, a release note is required:
Enter your extended release note in the format shown below. If the PR requires additional action from users switching to the new release, include the string "action required".

```release-note
Add your notes in this format, including the triple ticks.
```

-->

Additional documentation: <!--
This section can be removed if this PR does not include changes to our public documentation.

When adding links which point to resources within git repositories (px-docs, etc), please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
```docs
- [px/docs]: <link>
- [px/website]: <link>
```
-->
